### PR TITLE
Fix broken C++

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,10 +35,9 @@
     <option value="bash">bash</option>
     <option value="bqn">bqn</option>
     <option value="c">c</option>
-    <option value="c++">c++</option>
+    <option value="cpp">c++</option>
     <option value="clojure">clojure</option>
-    <option value="cpp">cpp</option>
-    <option value="cs">cs</option>
+    <option value="cs">c#</option>
     <option value="elixir">elixir</option>
     <option value="fs">fs</option>
     <option value="go">go</option>


### PR DESCRIPTION
The dropdown contained both C++ and cpp but only cpp seems to work. This merges them.

Also renames cs to C#